### PR TITLE
Change how DataStreamWriters are created

### DIFF
--- a/ProjectFiles/Assets/Scripts/Network/Client.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Client.cs
@@ -56,9 +56,8 @@ namespace Network
             Transform transform = world.GetPlayerTransform(playerID);
             Vector3 position = transform.position;
             Quaternion rotation = transform.rotation;
-            using (var writer = new DataStreamWriter(30, Allocator.Temp))
+            using (var writer = ClientNetworkEvent.ClientLocationUpdate.GetWriter(30, Allocator.Temp))
             {
-                writer.Write((byte) ClientNetworkEvent.ClientLocationUpdate);
                 writer.Write(position.x);
                 writer.Write(position.y);
                 writer.Write(position.z);
@@ -95,9 +94,8 @@ namespace Network
                     {
                         Debug.Log($"Client: Successfully connected to {serverIP}:{serverPort}.");
                         
-                        using (var writer = new DataStreamWriter(1, Allocator.Temp))
+                        using (var writer = ClientNetworkEvent.ClientHandshake.GetWriter(0, Allocator.Temp))
                         {
-                            writer.Write((byte) ClientNetworkEvent.ClientHandshake);
                             driver.Send(pipeline, connection, writer);
                         }
                         break;

--- a/ProjectFiles/Assets/Scripts/Network/NetworkEvents.cs
+++ b/ProjectFiles/Assets/Scripts/Network/NetworkEvents.cs
@@ -1,4 +1,6 @@
 using System;
+using Unity.Collections;
+using Unity.Networking.Transport;
 
 namespace Network
 {
@@ -14,4 +16,24 @@ namespace Network
         ServerHandshake      = 0x01,
         ServerLocationUpdate = 0x02,
     }
+
+
+
+    public static class NetworkEventExtension
+    {
+        public static DataStreamWriter GetWriter(this ClientNetworkEvent ev, int capacity, Allocator allocator)
+        {
+            var writer = new DataStreamWriter(capacity + 1, allocator);
+            writer.Write((byte) ev);
+            return writer;
+        }
+        
+        public static DataStreamWriter GetWriter(this ServerNetworkEvent ev, int capacity, Allocator allocator)
+        {
+            var writer = new DataStreamWriter(capacity + 1, allocator);
+            writer.Write((byte) ev);
+            return writer;
+        }
+    }
+    
 }

--- a/ProjectFiles/Assets/Scripts/Network/Server.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Server.cs
@@ -129,8 +129,9 @@ namespace Network
                 {
                     Debug.Log($"Server: Received handshake from {endpoint.IpAddress()}:{endpoint.Port}.");
 
-                    using (var writer = new DataStreamWriter(30, Allocator.Temp))
+                    using (var writer = ServerNetworkEvent.ServerHandshake.GetWriter(30, Allocator.Temp))
                     {
+                        
                         // Get a player id
                         int playerID = world.SpawnPlayer();
                         connectionPlayerIDs.Add(connectionID, playerID);
@@ -138,8 +139,7 @@ namespace Network
                         // Get spawn location
                         Transform transform = world.GetPlayerTransform(playerID);
                         var position = transform.position;
-
-                        writer.Write((byte) ServerNetworkEvent.ServerHandshake);
+                        
                         writer.Write((byte) playerID);
                         writer.Write(position.x);
                         writer.Write(position.y);


### PR DESCRIPTION
A `DataStreamWriter` is now created using extension method for the `NetworkEvent` enums, it is now automatically prefixed with identification byte.