### PR TITLE
Disconnect event

### DIFF
--- a/ProjectFiles/Assets/Scripts/Network/Client.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Client.cs
@@ -135,9 +135,7 @@ namespace Network
                 }
             }
         }
-
         
-
         private void HandleEvent(EventType eventType, DataStreamReader reader, DataStreamReader.Context readerContext)
         {
             Event ev;
@@ -176,6 +174,11 @@ namespace Network
                 case EventType.ServerEliminatePlayersEvent:
                 {
                     ev = new ServerEliminatePlayersEvent();
+                    break;
+                }
+                case EventType.ServerDisconnectEvent:
+                {
+                    ev = new ServerDisconnectEvent();
                     break;
                 }
                 default:
@@ -271,6 +274,12 @@ namespace Network
                 world.SetPlayerVelocity(playerID, ev.Velocities[playerID]);
                 world.SetPlayerAngularVelocity(playerID, ev.AngularVelocities[playerID]);
             }
+        }
+
+        public void Handle(ServerDisconnectEvent ev, NetworkConnection conn)
+        {
+            world.DestroyPlayer(ev.PlayerID);
+            Debug.Log($"Client: Destroyed player { ev.PlayerID } due to disconnect.");
         }
 
         public void Handle(ServerPreRoundStartEvent ev, NetworkConnection conn)

--- a/ProjectFiles/Assets/Scripts/Network/EventType.cs
+++ b/ProjectFiles/Assets/Scripts/Network/EventType.cs
@@ -16,5 +16,6 @@ namespace Network
         ServerRoundStartEvent       = 0x05,
         ServerRoundEndEvent         = 0x06,
         ServerEliminatePlayersEvent = 0x07,
+        ServerDisconnectEvent       = 0x08,
     }
 }

--- a/ProjectFiles/Assets/Scripts/Network/Events/ServerDisconnectEvent.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Events/ServerDisconnectEvent.cs
@@ -1,0 +1,41 @@
+﻿using Unity.Networking.Transport;
+
+namespace Network.Events
+{
+    public class ServerDisconnectEvent : Event
+    {
+        public ushort PlayerID { get; private set; }
+
+        public ServerDisconnectEvent()
+        {
+            ID = EventType.ServerDisconnectEvent;
+            Length = sizeof(ushort) + sizeof(byte);
+        }
+
+        public ServerDisconnectEvent(ushort playerID) : this()
+        {
+            PlayerID = playerID;
+        }
+
+        public override void Serialise(DataStreamWriter writer)
+        {
+            base.Serialise(writer);
+            writer.Write(PlayerID);
+        }
+
+        public override void Deserialise(DataStreamReader reader, ref DataStreamReader.Context context)
+        {
+            PlayerID = reader.ReadUShort(ref context);
+        }
+
+        public override void Handle(Server server, NetworkConnection connection)
+        {
+            server.Handle(this, connection);
+        }
+
+        public override void Handle(Client client, NetworkConnection connection)
+        {
+            client.Handle(this, connection);
+        }
+    }
+}

--- a/ProjectFiles/Assets/Scripts/Network/Events/ServerDisconnectEvent.cs.meta
+++ b/ProjectFiles/Assets/Scripts/Network/Events/ServerDisconnectEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9a8311f7846b4127aa41e5cb8e4e3945
+timeCreated: 1581633531

--- a/ProjectFiles/Assets/Scripts/Network/Server.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Server.cs
@@ -70,11 +70,7 @@ namespace Network
                     world.DestroyPlayer(playerID);
 
                     // Destroy the actual network connection
-                    // TODO: Is this needed???
-                    connections[i] = default(NetworkConnection);
-                            
                     Debug.Log($"Server: Destroyed player { playerID } due to disconnect.");
-                    
                     connections.RemoveAtSwapBack(i);
                     i--;
                 }
@@ -113,11 +109,8 @@ namespace Network
                             break;
                         }
                         case NetworkEvent.Type.Disconnect:
+                            connections[i] = default(NetworkConnection);
                             Debug.Log($"Server: {endpoint.IpAddress()}:{endpoint.Port} disconnected.");
-                            //TODO Duplicate with the loop above!
-                            var playerID = connections[i].InternalId;
-                            world.DestroyPlayer(playerID);
-                            connections.RemoveAtSwapBack(i);
                             break;
                     }
                 }

--- a/ProjectFiles/Assets/Scripts/Network/Server.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Server.cs
@@ -64,13 +64,6 @@ namespace Network
             {
                 if (!connections[i].IsCreated)
                 {
-                    var playerID = connections[i].InternalId;
-                    
-                    // Remove from world and player id mapping
-                    world.DestroyPlayer(playerID);
-
-                    // Destroy the actual network connection
-                    Debug.Log($"Server: Destroyed player { playerID } due to disconnect.");
                     connections.RemoveAtSwapBack(i);
                     i--;
                 }
@@ -109,8 +102,17 @@ namespace Network
                             break;
                         }
                         case NetworkEvent.Type.Disconnect:
+                            var playerID = connections[i].InternalId;
+                            // Remove from world and player id mapping
+                            world.DestroyPlayer(playerID);
+                    
+                            // Notify users of disconnect
+                            var disconnectEvent = new ServerDisconnectEvent((ushort) playerID);
+                            SendToAll(disconnectEvent);
+                    
+                            // Destroy the actual network connection
+                            Debug.Log($"Server: Destroyed player { playerID } due to disconnect.");
                             connections[i] = default(NetworkConnection);
-                            Debug.Log($"Server: {endpoint.IpAddress()}:{endpoint.Port} disconnected.");
                             break;
                     }
                 }
@@ -212,7 +214,7 @@ namespace Network
                 }
             }
         }
-
+        
         // Send Messages.
         public void SendLocationUpdates()
         {


### PR DESCRIPTION
Sends a disconnect event to all players when a player is disconnected.

Players are notified in the `NetworkEvent.Type.Disconnect` case rather than in the beginning for loop of `Server.HandleNetworkEvents()`: players weren't destroyed correctly since `connections[i] = default` set the connection ID back to 0.

I've tested with 2 clients but someone else verify for me 🎅🏿

Resolves #108, resolves #103 