### PR TITLE
Hotfix for incorrect deserialization of ServerGameEndEvent

### DIFF
--- a/ProjectFiles/Assets/Scripts/Network/Events/ServerEliminatePlayersEvent.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Events/ServerEliminatePlayersEvent.cs
@@ -5,12 +5,12 @@ namespace Network.Events {
     public class ServerEliminatePlayersEvent : Event {
         public ServerEliminatePlayersEvent() {
             ID = EventType.ServerEliminatePlayersEvent;
+            Length      = 2 * sizeof(ushort) + Players.Count * sizeof(int) + sizeof(byte);
         }
 
         public ServerEliminatePlayersEvent(ushort roundNumber, List<int> players) : this() {
             RoundNumber = roundNumber;
             Players     = players;
-            Length      = 2 * sizeof(ushort) + Players.Count * sizeof(int) + sizeof(byte);
         }
 
         public ushort    RoundNumber { get; private set; }
@@ -26,15 +26,13 @@ namespace Network.Events {
         }
 
         public override void Deserialise(DataStreamReader reader, ref DataStreamReader.Context context) {
-            RoundNumber = reader.ReadByte(ref context);
+            RoundNumber = reader.ReadUShort(ref context);
 
-            var playerCount = reader.ReadByte(ref context);
+            var playerCount = reader.ReadUShort(ref context);
             Players = new List<int>();
             for (var i = 0; i < playerCount; i++) {
-                Players.Add(reader.ReadByte(ref context));
+                Players.Add(reader.ReadInt(ref context));
             }
-
-            Length = sizeof(ushort) * (Players.Count + 2);
         }
 
         public override void Handle(Server server, NetworkConnection connection) {

--- a/ProjectFiles/Assets/Scripts/Network/Events/ServerEliminatePlayersEvent.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Events/ServerEliminatePlayersEvent.cs
@@ -5,12 +5,12 @@ namespace Network.Events {
     public class ServerEliminatePlayersEvent : Event {
         public ServerEliminatePlayersEvent() {
             ID = EventType.ServerEliminatePlayersEvent;
-            Length      = 2 * sizeof(ushort) + Players.Count * sizeof(int) + sizeof(byte);
         }
 
         public ServerEliminatePlayersEvent(ushort roundNumber, List<int> players) : this() {
             RoundNumber = roundNumber;
             Players     = players;
+            Length      = 2 * sizeof(ushort) + Players.Count * sizeof(int) + sizeof(byte);
         }
 
         public ushort    RoundNumber { get; private set; }
@@ -33,6 +33,7 @@ namespace Network.Events {
             for (var i = 0; i < playerCount; i++) {
                 Players.Add(reader.ReadInt(ref context));
             }
+            Length = 2 * sizeof(ushort) + Players.Count * sizeof(int) + sizeof(byte);
         }
 
         public override void Handle(Server server, NetworkConnection connection) {

--- a/ProjectFiles/Assets/Scripts/Network/Events/ServerGameEndEvent.cs
+++ b/ProjectFiles/Assets/Scripts/Network/Events/ServerGameEndEvent.cs
@@ -27,13 +27,13 @@ namespace Network.Events {
         }
 
         public override void Deserialise(DataStreamReader reader, ref DataStreamReader.Context context) {
-            var playerCount = reader.ReadByte(ref context);
+            var playerCount = reader.ReadUShort(ref context);
             Winners = new List<int>();
             for (var i = 0; i < playerCount; i++) {
-                Winners.Add(reader.ReadByte(ref context));
+                Winners.Add(reader.ReadInt(ref context));
             }
 
-            Length = sizeof(ushort) * (Winners.Count + 2);
+            Length = sizeof(ushort) + Winners.Count * sizeof(int) + sizeof(byte);
         }
 
         public override void Handle(Server server, NetworkConnection connection) {


### PR DESCRIPTION
Fixes the deserialization using the wrong types + length calculation, which causes player 0 to win all the time.

Tbh, this speaks volumes for how bad the network is at the moment, it's way too easy to slip up, there's like 5 places you need to remember to insert things, and it's just so clunky. we should refactor soon pls :)))